### PR TITLE
Update workflow badge URL in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![codecov](https://codecov.io/gh/SecretLake/test-ci/branch/master/graph/badge.svg?token=6ZZHPQ76OO)](https://codecov.io/gh/SecretLake/test-ci)
-![tests](https://github.com/SecretLake/test-ci/actions/workflows/run_unittests_and_linting.yml/badge.svg?branch=main)
+![tests](https://github.com/straussmaximilian/tasklit/actions/workflows/run_unittests_and_linting.yml/badge.svg?branch=main)
 
 
 # tasklit


### PR DESCRIPTION
Forgot to change the workflow badge URL from my test repo to tasklit. Changed it now.